### PR TITLE
docs: padronizando nomenclatura da extensão

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change Log
+# Changelog
 
 All notable changes to the "mapi" extension will be documented in this file.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ O formato `.mapi` é projetado para criar documentação de API em um formato ma
 
 1. Abra o VS Code.
 2. Vá para a Visual Studio Code Marketplace.
-3. Pesquise por "Mapi API Markdown language support".
+3. Pesquise por "mAPI".
 4. Instale a extensão.
 5. Reinicie o VS Code.
 
@@ -24,7 +24,7 @@ Após a instalação, todos os arquivos com a extensão `.mapi` terão automatic
 
 ## Contribuindo
 
-Estamos abertos a contribuições! Se você encontrou um bug ou deseja adicionar um novo recurso, sinta-se à vontade para abrir uma issue ou pull request no nosso [https://github.com/EHavel/mapi](https://github.com/EHavel/mapi).
+Estamos abertos a contribuições! Se você encontrou um bug ou deseja adicionar um novo recurso, sinta-se à vontade para abrir uma issue ou pull request no repositório [https://github.com/EHavel/mapi](https://github.com/EHavel/mapi).
 
 ## Licença
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapi",
-  "displayName": "Mapi",
-  "description": "Api Markdown",
+  "displayName": "mAPI",
+  "description": "Markdown API",
   "version": "0.0.1",
   "author": "Eric Havel",
   "license": "GPL-3.0-only",
@@ -25,7 +25,9 @@
         "id": "mapi",
         "aliases": [
           "Mapi",
-          "mapi"
+          "mapi",
+          "MAPI",
+          "mAPI"
         ],
         "extensions": [
           ".mapi"

--- a/syntaxes/mapi.tmLanguage.json
+++ b/syntaxes/mapi.tmLanguage.json
@@ -1,13 +1,15 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "Mapi",
+  "name": "mAPI",
   "patterns": [
     {
       "name": "custom.response-section",
       "begin": "^(## (Response|Models))",
       "end": "(?=^(## [^\\s]+|$)(?!\\s*$))",
       "beginCaptures": {
-        "1": { "name": "custom.green" }
+        "1": {
+          "name": "custom.green"
+        }
       },
       "patterns": [
         {


### PR DESCRIPTION
Padronizando para `mAPI`, e aproveitei para ajustar alguns detalhes nas docs.